### PR TITLE
Converter tool for RDF databases

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,10 @@ Graphs and grammars for experiments in context free path querying algorithms.
 
 ## How to start
 
-Just run init.py: 
+* Install requirements via pip:
+```pip install -r requirements.txt```
 
+* run `init.py`: 
 ```python3 init.py```
 
 The script downloads data and [GTgraph](http://www.cse.psu.edu/~kxm85/software/GTgraph/) - a suite of synthetic graph generators.

--- a/init.py
+++ b/init.py
@@ -91,6 +91,14 @@ def unpack_graphs():
         print ('Unpack ', arch, ' to ', to)
         unpack(arch, to)
 
+def to_file(filepath, graph):
+    with open(filepath, 'w') as out_file:
+        for t in graph:
+            s = t[0]
+            p = t[1]
+            o = t[2]
+            out_file.write('%s %s %s\n'%(s,p,o))
+
 def gen_sparse_graph(target_dir, vertices, prob, add_back_edge):
  
     subprocess.run([GT_GRAPH, '-t', '0', '-n', '%s'%(vertices), '-p', '%s'%(prob), '-o', TMP_FILE])

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+isodate==0.6.0
+pkg-resources==0.0.0
+pyparsing==2.4.4
+rdflib==4.2.2
+six==1.13.0

--- a/tools/convconfig
+++ b/tools/convconfig
@@ -1,0 +1,2 @@
+http://www.w3.org/2000/01/rdf-schema#subClassOf SCO
+http://www.w3.org/1999/02/22-rdf-syntax-ns#type T

--- a/tools/converter.py
+++ b/tools/converter.py
@@ -1,0 +1,44 @@
+"""
+RDF converter from popular formats (XML, Turtle, etc.) to simple triple
+format (.txt).
+
+Usage:
+- Create a conversion configuration file. Each line must contain an IRI, a
+  whitespace character and a string to replace the IRI by.
+- Run converter.py <data> <config>
+- Result will have the same name of the input data, with .txt extension.
+  The graph will contain explicit inverted edges added an 'R'.
+"""
+
+import rdflib, sys, os
+
+if len(sys.argv) < 2:
+	print('Usage: converter.py <data> <config>')
+	exit()
+
+replace = {} # map for replacing predicates
+config = sys.argv[2]
+for l in open(config,'r').readlines():
+	pair = l.split(' ')
+	old = rdflib.URIRef(pair[0].strip(' '))
+	new = pair[1].strip('\n').strip(' ')
+	replace[old] = new
+
+res = {}    # map from resources to integer ids
+next_id = 0 # id counter
+
+graph = rdflib.Graph()
+graph.parse(sys.argv[1])
+
+out = open(os.path.splitext(sys.argv[1])[0]+'.txt','w') # output file
+for s,p,o in graph:
+	for r in [s,o]:
+		if r not in res:
+			res[r] = str(next_id)
+			next_id += 1
+
+	if p in replace:
+		out.write(res[s]+' '+replace[p]+' ' +res[o]+'\n')
+		out.write(res[o]+' '+replace[p]+'R '+res[s]+'\n')
+	else:
+		out.write(res[s]+' OTHER '+res[o]+'\n')


### PR DESCRIPTION
Tool for converting RDF databases from the most popular formats to our simple txt format.
Uses rdflib to read from any format (pip installation required).