### PR TITLE
The first variable in cnf must be starting symbol in grammar_to_cnf result

### DIFF
--- a/tools/grammar_to_cnf/grammar_to_cnf.py
+++ b/tools/grammar_to_cnf/grammar_to_cnf.py
@@ -113,7 +113,7 @@ def to_txt(cfg):
     variables, productions, terminals = '', '', ''
 
     for var in cfg.variables:
-        if var not in cfg.variables:
+        if var != cfg.start_symbol:
             variables += f'{var.value} '
     for ter in cfg.terminals:
         terminals += f'{ter.value} '


### PR DESCRIPTION
@azaat [был прав](https://github.com/JetBrains-Research/CFPQ_Data/pull/17#discussion_r425974906)