### PR TITLE
RSM deprecation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,6 @@ jobs:
     strategy:
       matrix:
         os: [
-            ubuntu-16.04,
             ubuntu-18.04,
             ubuntu-20.04,
             ubuntu-latest,

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,6 @@ jobs:
     strategy:
       matrix:
         os: [
-            ubuntu-16.04,
             ubuntu-18.04,
             ubuntu-20.04,
             ubuntu-latest,

--- a/cfpq_data/__init__.py
+++ b/cfpq_data/__init__.py
@@ -7,7 +7,7 @@ structure, dynamics, and functions of complex Graphs and Grammars used for
 experimental analysis of context-free path querying algorithms
 """
 
-__version__ = "1.0.1"
+__version__ = "1.0.2"
 
 import cfpq_data.config
 from cfpq_data.config import *

--- a/cfpq_data/grammars/converters/__init__.py
+++ b/cfpq_data/grammars/converters/__init__.py
@@ -1,3 +1,4 @@
 from cfpq_data.grammars.converters.cfg import *
 from cfpq_data.grammars.converters.cnf import *
 from cfpq_data.grammars.converters.rsm import *
+from cfpq_data.grammars.converters.rsa import *

--- a/cfpq_data/grammars/converters/cfg.py
+++ b/cfpq_data/grammars/converters/cfg.py
@@ -1,13 +1,17 @@
 """Create a context-free grammar
 from different formats.
 """
-from pyformlang.cfg import CFG
+import re
+
+from pyformlang.cfg import CFG, Variable, Production, Terminal
+from pyformlang.rsa import RecursiveAutomaton as RSA
 
 from cfpq_data.grammars.rsm import RSM
 
 __all__ = [
     "cfg_from_cnf",
     "cfg_from_rsm",
+    "cfg_from_rsa",
 ]
 
 
@@ -43,9 +47,15 @@ def cfg_from_cnf(cnf: CFG) -> CFG:
     return CFG.from_text(cnf.to_text(), cnf.start_symbol)
 
 
+# TODO: Remove in cfpq_data 2.0.0
 def cfg_from_rsm(rsm: RSM) -> CFG:
     """Create a context-free grammar [1]_
     from given Recursive State Machine [2]_.
+
+    .. deprecated:: 2.0.0
+
+       The function `cfg_from_rsm` will be replaced
+       with function `cfg_from_rsa`
 
     Parameters
     ----------
@@ -72,4 +82,91 @@ def cfg_from_rsm(rsm: RSM) -> CFG:
        and Semyon Grigorev "Context-Free Path Querying
        by Kronecker Product", ADBIS 2020, pp 49-59, 2020
     """
+    import warnings
+
+    msg = (
+        "\nThe function `cfg_from_rsm` will be replaced "
+        "with function `cfg_from_rsa` in "
+        "cfpq_data 2.0.0\n"
+    )
+
+    warnings.warn(msg, FutureWarning, stacklevel=2)
+
     return rsm.to_cfg()
+
+
+def cfg_from_rsa(rsa: RSA) -> CFG:
+    """Create a context-free grammar [1]_
+    from given Recursive State Automaton [2]_.
+
+    Parameters
+    ----------
+    rsa : RSA
+        Recursive State Automaton.
+
+    Examples
+    --------
+    >>> import cfpq_data
+    >>> cfg = CFG.from_text("S -> (a S* b S*)*")
+    >>> rsa = RSA.from_cfg(cfg)
+    >>> cfg = cfpq_data.cfg_from_rsa(rsa)
+    >>> [cfg.contains(word) for word in ["", "ab", "aabb"]]
+    [True, True, True]
+
+    Returns
+    -------
+    cfg : CFG
+        Context-free grammar.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Context-free_grammar#Formal_definitions
+    .. [2] Alur R., Etessami K., Yannakakis M. (2001) Analysis of Recursive State Machines.
+       In: Berry G., Comon H., Finkel A. (eds) Computer Aided Verification. CAV 2001.
+       Lecture Notes in Computer Science, vol 2102.
+       Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-44585-4_18
+    """
+    variables = set()
+    terminals = set()
+    productions = set()
+
+    for symbol in rsa.labels:
+        dfa = rsa.get_box(symbol).dfa
+
+        variables.add(Variable(symbol.value))
+
+        naming = {dfa.start_state: Variable(symbol.value)}
+
+        for state in dfa.states:
+            if state not in naming:
+                naming[state] = Variable(f"S{len(naming)}")
+                variables.add(naming[state])
+
+            if state in dfa.final_states:
+                productions.add(Production(naming[state], []))
+
+        for v, label, to in dfa._transition_function.get_edges():
+            if label.value == label.value.lower():
+                try:
+                    label_value = re.search('"TER:(.*)"', label.value).group(1)
+                except AttributeError:
+                    label_value = label.value
+
+                terminals.add(Terminal(label_value))
+                production_label = Terminal(label_value)
+            else:
+                try:
+                    label_value = re.search('"VAR:(.*)"', label.value).group(1)
+                except AttributeError:
+                    label_value = label.value
+
+                production_label = Variable(label_value)
+
+            productions.add(Production(naming[v], [production_label, naming[to]]))
+
+    return CFG(
+        variables=variables,
+        terminals=terminals,
+        start_symbol=Variable(rsa.initial_label.value),
+        productions=productions,
+    )

--- a/cfpq_data/grammars/converters/cnf.py
+++ b/cfpq_data/grammars/converters/cnf.py
@@ -3,13 +3,15 @@ in Chomsky normal form
 from different formats.
 """
 from pyformlang.cfg import CFG, Production
+from pyformlang.rsa import RecursiveAutomaton as RSA
 
-from cfpq_data.grammars.converters.cfg import cfg_from_rsm
+from cfpq_data.grammars.converters.cfg import cfg_from_rsm, cfg_from_rsa
 from cfpq_data.grammars.rsm import RSM
 
 __all__ = [
     "cnf_from_cfg",
     "cnf_from_rsm",
+    "cnf_from_rsa",
 ]
 
 
@@ -52,10 +54,16 @@ def cnf_from_cfg(cfg: CFG) -> CFG:
     return cnf
 
 
+# TODO: Remove in cfpq_data 2.0.0
 def cnf_from_rsm(rsm: RSM) -> CFG:
     """Create a context-free grammar
     in Chomsky normal form [1]_
     from Recursive State Machine [2]_.
+
+    .. deprecated:: 2.0.0
+
+       The function `cnf_from_rsm` will be replaced
+       with function `cnf_from_rsa`
 
     Parameters
     ----------
@@ -83,4 +91,50 @@ def cnf_from_rsm(rsm: RSM) -> CFG:
        and Semyon Grigorev "Context-Free Path Querying
        by Kronecker Product", ADBIS 2020, pp 49-59, 2020
     """
+    import warnings
+
+    msg = (
+        "\nThe function `cnf_from_rsm` will be replaced "
+        "with function `cnf_from_rsa` in "
+        "cfpq_data 2.0.0\n"
+    )
+
+    warnings.warn(msg, FutureWarning, stacklevel=2)
+
     return cnf_from_cfg(cfg_from_rsm(rsm))
+
+
+def cnf_from_rsa(rsa: RSA) -> CFG:
+    """Create a context-free grammar
+    in Chomsky normal form [1]_
+    from Recursive State Automaton [2]_.
+
+    Parameters
+    ----------
+    rsa : RSA
+        Recursive State Automaton.
+
+    Examples
+    --------
+    >>> import cfpq_data
+    >>> cfg = CFG.from_text("S -> (a S* b S*)*")
+    >>> rsa = RSA.from_cfg(cfg)
+    >>> cnf = cfpq_data.cnf_from_rsa(rsa)
+    >>> [cnf.contains(word) for word in ["", "ab", "aabb"]]
+    [True, True, True]
+
+    Returns
+    -------
+    cnf : CFG
+        Context-free grammar
+        in Chomsky normal form.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Chomsky_normal_form
+    .. [2] Alur R., Etessami K., Yannakakis M. (2001) Analysis of Recursive State Machines.
+       In: Berry G., Comon H., Finkel A. (eds) Computer Aided Verification. CAV 2001.
+       Lecture Notes in Computer Science, vol 2102.
+       Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-44585-4_18
+    """
+    return cnf_from_cfg(cfg_from_rsa(rsa))

--- a/cfpq_data/grammars/converters/rsa.py
+++ b/cfpq_data/grammars/converters/rsa.py
@@ -1,0 +1,74 @@
+"""Create a Recursive State Automaton
+from different formats.
+"""
+from pyformlang.cfg import CFG
+from pyformlang.rsa import RecursiveAutomaton as RSA
+
+__all__ = [
+    "rsa_from_cfg",
+    "rsa_from_cnf",
+]
+
+
+def rsa_from_cfg(cfg: CFG) -> RSA:
+    """Create a Recursive State Automaton [2]_
+    from context-free grammar [1]_.
+
+    Parameters
+    ----------
+    cfg : CFG
+        Context-free grammar.
+
+    Examples
+    --------
+    >>> import cfpq_data
+    >>> cfg = cfpq_data.cfg_from_text("S -> a S b S | a b")
+    >>> rsa = cfpq_data.rsa_from_cfg(cfg)
+
+    Returns
+    -------
+    rsa : RSA
+        Recursive State Automaton.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Context-free_grammar#Formal_definitions
+    .. [2] Alur R., Etessami K., Yannakakis M. (2001) Analysis of Recursive State Machines.
+       In: Berry G., Comon H., Finkel A. (eds) Computer Aided Verification. CAV 2001.
+       Lecture Notes in Computer Science, vol 2102.
+       Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-44585-4_18
+    """
+    return RSA.from_cfg(cfg)
+
+
+def rsa_from_cnf(cnf: CFG) -> RSA:
+    """Create a Recursive State Automaton [2]_
+    from context-free grammar
+    in Chomsky normal form [1]_.
+
+    Parameters
+    ----------
+    cnf : CFG
+        Context-free grammar
+        in Chomsky normal form.
+
+    Examples
+    --------
+    >>> import cfpq_data
+    >>> cnf = cfpq_data.cnf_from_text("S -> a S b S | a b")
+    >>> rsa = cfpq_data.rsa_from_cnf(cnf)
+
+    Returns
+    -------
+    rsa : RSA
+        Recursive State Automaton.
+
+    References
+    ----------
+    .. [1] https://en.wikipedia.org/wiki/Chomsky_normal_form
+    .. [2] Alur R., Etessami K., Yannakakis M. (2001) Analysis of Recursive State Machines.
+       In: Berry G., Comon H., Finkel A. (eds) Computer Aided Verification. CAV 2001.
+       Lecture Notes in Computer Science, vol 2102.
+       Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-44585-4_18
+    """
+    return rsa_from_cfg(cnf)

--- a/cfpq_data/grammars/converters/rsm.py
+++ b/cfpq_data/grammars/converters/rsm.py
@@ -12,9 +12,15 @@ __all__ = [
 ]
 
 
+# TODO: Remove in cfpq_data 2.0.0
 def rsm_from_cfg(cfg: CFG) -> RSM:
     """Create a Recursive State Machine [2]_
     from context-free grammar [1]_.
+
+    .. deprecated:: 2.0.0
+
+       The function `rsm_from_cfg` will be replaced
+       with function `rsa_from_cfg`
 
     Parameters
     ----------
@@ -42,13 +48,29 @@ def rsm_from_cfg(cfg: CFG) -> RSM:
        Lecture Notes in Computer Science, vol 2102.
        Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-44585-4_18
     """
+    import warnings
+
+    msg = (
+        "\nThe function `rsm_from_cfg` will be replaced "
+        "with function `rsa_from_cfg` in "
+        "cfpq_data 2.0.0\n"
+    )
+
+    warnings.warn(msg, FutureWarning, stacklevel=2)
+
     return rsm_from_text(cfg.to_text(), cfg.start_symbol)
 
 
+# TODO: Remove in cfpq_data 2.0.0
 def rsm_from_cnf(cnf: CFG) -> RSM:
     """Create a Recursive State Machine [2]_
     from context-free grammar
     in Chomsky normal form [1]_.
+
+    .. deprecated:: 2.0.0
+
+       The function `rsm_from_cnf` will be replaced
+       with function `rsa_from_cnf`
 
     Parameters
     ----------
@@ -77,4 +99,14 @@ def rsm_from_cnf(cnf: CFG) -> RSM:
        Lecture Notes in Computer Science, vol 2102.
        Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-44585-4_18
     """
+    import warnings
+
+    msg = (
+        "\nThe function `rsm_from_cnf` will be replaced "
+        "with function `rsa_from_cnf` in "
+        "cfpq_data 2.0.0\n"
+    )
+
+    warnings.warn(msg, FutureWarning, stacklevel=2)
+
     return rsm_from_text(cnf.to_text(), cnf.start_symbol)

--- a/cfpq_data/grammars/readwrite/__init__.py
+++ b/cfpq_data/grammars/readwrite/__init__.py
@@ -1,3 +1,4 @@
 from cfpq_data.grammars.readwrite.cfg import *
 from cfpq_data.grammars.readwrite.cnf import *
 from cfpq_data.grammars.readwrite.rsm import *
+from cfpq_data.grammars.readwrite.rsa import *

--- a/cfpq_data/grammars/readwrite/rsa.py
+++ b/cfpq_data/grammars/readwrite/rsa.py
@@ -1,0 +1,188 @@
+"""Read (and write) a Recursive State Automaton
+from (and to) different sources.
+"""
+from pathlib import Path
+from typing import Union
+
+from pyformlang.cfg import Epsilon, Variable
+from pyformlang.finite_automaton.finite_automaton import to_symbol
+from pyformlang.regular_expression import Regex
+from pyformlang.rsa import Box, RecursiveAutomaton as RSA
+
+__all__ = [
+    "rsa_from_text",
+    "rsa_to_text",
+    "rsa_from_txt",
+    "rsa_to_txt",
+]
+
+
+def rsa_from_text(source: str, start_symbol: Variable = Variable("S")) -> RSA:
+    """Create a Recursive State Automaton [1]_ from text.
+
+    Parameters
+    ----------
+    source : str
+        The text with which
+        the Recursive State Machine
+        will be created.
+
+    start_symbol : Variable
+        Start symbol of a Recursive State Machine.
+
+    Examples
+    --------
+    >>> import cfpq_data
+    >>> rsa = cfpq_data.rsa_from_text("S -> (a S* b S*)*")
+
+    Returns
+    -------
+    rsa : RSA
+        Recursive State Automaton.
+
+    References
+    ----------
+    .. [1] Alur R., Etessami K., Yannakakis M. (2001) Analysis of Recursive State Machines.
+       In: Berry G., Comon H., Finkel A. (eds) Computer Aided Verification. CAV 2001.
+       Lecture Notes in Computer Science, vol 2102.
+       Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-44585-4_18
+    """
+    productions = dict()
+    boxes = set()
+    labels = set()
+
+    for production in source.splitlines():
+        if " -> " not in production:
+            continue
+
+        head, body = production.split(" -> ")
+        labels.add(to_symbol(head))
+
+        if body == "":
+            body = Epsilon().to_text()
+
+        if head in productions:
+            productions[head] += " | " + body
+        else:
+            productions[head] = body
+
+    for head, body in productions.items():
+        boxes.add(Box(Regex(body).to_epsilon_nfa().minimize(), to_symbol(head)))
+
+    return RSA(labels, to_symbol(start_symbol), boxes)
+
+
+def rsa_to_text(rsa: RSA) -> str:
+    """Turns a Recursive State Automaton [1]_
+    into its text representation.
+
+    Parameters
+    ----------
+    rsa : RSA
+        Recursive State Automaton.
+
+    Examples
+    --------
+    >>> import cfpq_data
+    >>> rsa = cfpq_data.rsa_from_text("S -> (a S* b S*)*")
+    >>> text = cfpq_data.rsa_to_text(rsa)
+
+    Returns
+    -------
+    text : str
+        Recursive State Automaton text representation.
+
+    References
+    ----------
+    .. [1] Alur R., Etessami K., Yannakakis M. (2001) Analysis of Recursive State Machines.
+       In: Berry G., Comon H., Finkel A. (eds) Computer Aided Verification. CAV 2001.
+       Lecture Notes in Computer Science, vol 2102.
+       Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-44585-4_18
+    """
+    productions = list()
+    for symbol in rsa.labels:
+        box = rsa.get_box(symbol)
+        productions.append(f"{box.label.value} -> {box.dfa.to_regex()}")
+    return "\n".join(productions)
+
+
+def rsa_from_txt(
+    source: Union[Path, str], start_symbol: Variable = Variable("S")
+) -> RSA:
+    """Create a Recursive State Automaton [1]_
+    from TXT file.
+
+    Parameters
+    ----------
+    source : Union[Path, str]
+        The path to the TXT file with which
+        the Recursive State Machine
+        will be created.
+
+    start_symbol : Variable
+        Start symbol of a Recursive State Machine.
+
+    Examples
+    --------
+    >>> import cfpq_data
+    >>> rsa_1 = cfpq_data.rsa_from_text("S -> (a S* b S*)*")
+    >>> path = cfpq_data.rsa_to_txt(rsa_1, "test.txt")
+    >>> rsa = cfpq_data.rsa_from_txt(path)
+
+    Returns
+    -------
+    rsa : RSA
+        Recursive State Automaton.
+
+    References
+    ----------
+    .. [1] Alur R., Etessami K., Yannakakis M. (2001) Analysis of Recursive State Machines.
+       In: Berry G., Comon H., Finkel A. (eds) Computer Aided Verification. CAV 2001.
+       Lecture Notes in Computer Science, vol 2102.
+       Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-44585-4_18
+    """
+    with open(source, "r") as fin:
+        productions = fin.read()
+    return rsa_from_text(productions, start_symbol)
+
+
+def rsa_to_txt(rsa: RSA, destination: Union[Path, str]) -> Path:
+    """Saves a Recursive State Automaton
+    text representation
+    into TXT file.
+
+    Parameters
+    ----------
+    rsa : RSA
+        Recursive State Automaton.
+
+    destination : Union[Path, str]
+        The path to the TXT file
+        where Recursive State Machine
+        text representation
+        will be saved.
+
+    Examples
+    --------
+    >>> import cfpq_data
+    >>> rsa = cfpq_data.rsa_from_text("S -> (a S* b S*)*")
+    >>> path = cfpq_data.rsa_to_txt(rsa, "test.txt")
+
+    Returns
+    -------
+    path : Path
+        The path to the TXT file
+        where Recursive State Automaton
+        text representation
+        will be saved.
+
+    References
+    ----------
+    .. [1] Alur R., Etessami K., Yannakakis M. (2001) Analysis of Recursive State Machines.
+       In: Berry G., Comon H., Finkel A. (eds) Computer Aided Verification. CAV 2001.
+       Lecture Notes in Computer Science, vol 2102.
+       Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-44585-4_18
+    """
+    with open(destination, "w") as fout:
+        fout.write(rsa_to_text(rsa))
+    return Path(destination).resolve()

--- a/cfpq_data/grammars/readwrite/rsm.py
+++ b/cfpq_data/grammars/readwrite/rsm.py
@@ -17,8 +17,14 @@ __all__ = [
 ]
 
 
+# TODO: Remove in cfpq_data 2.0.0
 def rsm_from_text(source: str, start_symbol: Variable = Variable("S")) -> RSM:
     """Create a Recursive State Machine [1]_ from text.
+
+    .. deprecated:: 2.0.0
+
+       The function `rsm_from_text` will be replaced
+       with function `rsa_from_text`
 
     Parameters
     ----------
@@ -49,6 +55,16 @@ def rsm_from_text(source: str, start_symbol: Variable = Variable("S")) -> RSM:
        Lecture Notes in Computer Science, vol 2102.
        Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-44585-4_18
     """
+    import warnings
+
+    msg = (
+        "\nThe function `rsm_from_text` will be replaced "
+        "with function `rsa_from_text` in "
+        "cfpq_data 2.0.0\n"
+    )
+
+    warnings.warn(msg, FutureWarning, stacklevel=2)
+
     boxes = list()
 
     for production in source.splitlines():
@@ -68,9 +84,15 @@ def rsm_from_text(source: str, start_symbol: Variable = Variable("S")) -> RSM:
     return RSM(start_symbol, boxes)
 
 
+# TODO: Remove in cfpq_data 2.0.0
 def rsm_to_text(rsm: RSM) -> str:
     """Turns a Recursive State Machine [1]_
     into its text representation.
+
+    .. deprecated:: 2.0.0
+
+       The function `rsm_to_text` will be replaced
+       with function `rsa_to_text`
 
     Parameters
     ----------
@@ -95,14 +117,30 @@ def rsm_to_text(rsm: RSM) -> str:
        Lecture Notes in Computer Science, vol 2102.
        Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-44585-4_18
     """
+    import warnings
+
+    msg = (
+        "\nThe function `rsm_to_text` will be replaced "
+        "with function `rsa_to_text` in "
+        "cfpq_data 2.0.0\n"
+    )
+
+    warnings.warn(msg, FutureWarning, stacklevel=2)
+
     return rsm.to_text()
 
 
+# TODO: Remove in cfpq_data 2.0.0
 def rsm_from_txt(
     source: Union[Path, str], start_symbol: Variable = Variable("S")
 ) -> RSM:
     """Create a Recursive State Machine [1]_
     from TXT file.
+
+    .. deprecated:: 2.0.0
+
+       The function `rsm_from_txt` will be replaced
+       with function `rsa_from_txt`
 
     Parameters
     ----------
@@ -133,15 +171,31 @@ def rsm_from_txt(
        Lecture Notes in Computer Science, vol 2102.
        Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-44585-4_18
     """
+    import warnings
+
+    msg = (
+        "\nThe function `rsm_from_txt` will be replaced "
+        "with function `rsa_from_txt` in "
+        "cfpq_data 2.0.0\n"
+    )
+
+    warnings.warn(msg, FutureWarning, stacklevel=2)
+
     with open(source, "r") as fin:
         productions = fin.read()
     return rsm_from_text(productions, start_symbol)
 
 
+# TODO: Remove in cfpq_data 2.0.0
 def rsm_to_txt(rsm: RSM, destination: Union[Path, str]) -> Path:
     """Saves a Recursive State Machine
     text representation
     into TXT file.
+
+    .. deprecated:: 2.0.0
+
+       The function `rsm_to_txt` will be replaced
+       with function `rsa_to_txt`
 
     Parameters
     ----------
@@ -175,6 +229,16 @@ def rsm_to_txt(rsm: RSM, destination: Union[Path, str]) -> Path:
        Lecture Notes in Computer Science, vol 2102.
        Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-44585-4_18
     """
+    import warnings
+
+    msg = (
+        "\nThe function `rsm_to_txt` will be replaced "
+        "with function `rsa_to_txt` in "
+        "cfpq_data 2.0.0\n"
+    )
+
+    warnings.warn(msg, FutureWarning, stacklevel=2)
+
     with open(destination, "w") as fout:
         fout.write(rsm_to_text(rsm))
     return Path(destination).resolve()

--- a/cfpq_data/grammars/rsm.py
+++ b/cfpq_data/grammars/rsm.py
@@ -9,8 +9,15 @@ from pyformlang.finite_automaton import DeterministicFiniteAutomaton
 __all__ = ["RSM"]
 
 
+# TODO: Remove in cfpq_data 2.0
 class RSM:
     """Recursive State Machine [1]_.
+
+    .. deprecated:: 2.0.0
+
+       The class `RSM` will be replaced
+       with class `RecursiveAutomaton`
+       from pyformlang
 
     References
     ----------
@@ -42,6 +49,17 @@ class RSM:
            Lecture Notes in Computer Science, vol 2102.
            Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-44585-4_18
         """
+        import warnings
+
+        msg = (
+            "\nThe class `RSM` will be replaced "
+            "with class `RecursiveAutomaton` "
+            "from pyformlang "
+            "in cfpq_data 2.0.0\n"
+        )
+
+        warnings.warn(msg, FutureWarning, stacklevel=2)
+
         self.start_symbol: Variable = start_symbol
         self.boxes: Sequence[Tuple[Variable, DeterministicFiniteAutomaton]] = boxes
 

--- a/cfpq_data/graphs/generators/labeled_scale_free_graph.py
+++ b/cfpq_data/graphs/generators/labeled_scale_free_graph.py
@@ -67,7 +67,7 @@ def labeled_scale_free_graph(
     >>> g.number_of_nodes()
     42
     >>> g.number_of_edges()
-    88
+    81
 
     Returns
     -------

--- a/docs/reference/grammars/grammars_converters.rst
+++ b/docs/reference/grammars/grammars_converters.rst
@@ -18,3 +18,4 @@ Grammar converters
    cfg
    cnf
    rsm
+   rsa

--- a/docs/reference/grammars/grammars_readwrite.rst
+++ b/docs/reference/grammars/grammars_readwrite.rst
@@ -18,3 +18,4 @@ Reading and writing grammars
    cfg
    cnf
    rsm
+   rsa

--- a/tests/grammars/converters/test_rsa_converters.py
+++ b/tests/grammars/converters/test_rsa_converters.py
@@ -1,4 +1,3 @@
-# TODO: Remove in cfpq_data 2.0.0
 import pytest
 
 import cfpq_data
@@ -11,14 +10,16 @@ cnf_2 = cfpq_data.cnf_from_text("S -> sco_r S sco | t_r S t | sco_r sco | t_r t"
 
 
 @pytest.mark.parametrize("cfg", [cfg_1, cfg_2])
-def test_rsm_from_cfg(cfg):
-    rsm = cfpq_data.rsm_from_cfg(cfg)
+def test_rsa_from_cfg(cfg):
+    rsa = cfpq_data.rsa_from_cfg(cfg)
+    cfg_from_rsa = cfpq_data.cfg_from_rsa(rsa)
     for word in cfg.get_words(4):
-        assert rsm.contains(word) and cfg.contains(word)
+        assert cfg_from_rsa.contains(word) and cfg.contains(word)
 
 
 @pytest.mark.parametrize("cnf", [cnf_1, cnf_2])
-def test_rsm_from_cnf(cnf):
-    rsm = cfpq_data.rsm_from_cnf(cnf)
+def test_rsa_from_cnf(cnf):
+    rsa = cfpq_data.rsa_from_cnf(cnf)
+    cfg_from_rsa = cfpq_data.cfg_from_rsa(rsa)
     for word in cnf.get_words(4):
-        assert rsm.contains(word) and cnf.contains(word)
+        assert cfg_from_rsa.contains(word) and cnf.contains(word)

--- a/tests/grammars/readwrite/test_rsa_readwrite.py
+++ b/tests/grammars/readwrite/test_rsa_readwrite.py
@@ -1,0 +1,61 @@
+import os
+import tempfile
+
+import pytest
+
+import cfpq_data
+
+grammar_1 = "S -> a b"
+grammar_2 = "S -> a"
+
+
+@pytest.mark.parametrize(
+    "grammar, expected",
+    [(grammar_1, ["ab"]), (grammar_2, ["a"])],
+)
+def test_rsa_from_text(grammar, expected):
+    rsa = cfpq_data.rsa_from_text(grammar)
+    cfg_from_rsa = cfpq_data.cfg_from_rsa(rsa)
+
+    for word in expected:
+        if word is not None:
+            assert cfg_from_rsa.contains(word)
+
+
+@pytest.mark.parametrize(
+    "grammar, expected",
+    [
+        (grammar_1, {"S -> ($.(a.b))"}),
+        (grammar_2, {"S -> ($.a)"}),
+    ],
+)
+def test_rsa_to_text(grammar, expected):
+    rsa = cfpq_data.rsa_from_text(grammar)
+
+    actual = set(cfpq_data.rsa_to_text(rsa).splitlines())
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "grammar",
+    [
+        grammar_1,
+        grammar_2,
+    ],
+)
+def test_rsa_from_and_to_txt(grammar):
+    (fd, fname) = tempfile.mkstemp()
+
+    rsa_1 = cfpq_data.rsa_from_text(grammar)
+
+    path = cfpq_data.rsa_to_txt(rsa_1, fname)
+
+    rsa_2 = cfpq_data.rsa_from_txt(path)
+
+    os.close(fd)
+    os.unlink(fname)
+
+    assert set(cfpq_data.rsa_to_text(rsa_1).splitlines()) == set(
+        cfpq_data.rsa_to_text(rsa_2).splitlines()
+    )

--- a/tests/grammars/readwrite/test_rsa_readwrite.py
+++ b/tests/grammars/readwrite/test_rsa_readwrite.py
@@ -7,14 +7,22 @@ import cfpq_data
 
 grammar_1 = "S -> a b"
 grammar_2 = "S -> a"
+grammar_3 = "S -> a\nS -> b"
+grammar_4 = "S -> \n#comment"
 
 
 @pytest.mark.parametrize(
     "grammar, expected",
-    [(grammar_1, ["ab"]), (grammar_2, ["a"])],
+    [
+        (grammar_1, ["ab"]),
+        (grammar_2, ["a"]),
+        (grammar_3, ["a", "b"]),
+        (grammar_4, [""]),
+    ],
 )
 def test_rsa_from_text(grammar, expected):
     rsa = cfpq_data.rsa_from_text(grammar)
+    print(cfpq_data.rsa_to_text(rsa))
     cfg_from_rsa = cfpq_data.cfg_from_rsa(rsa)
 
     for word in expected:
@@ -27,6 +35,7 @@ def test_rsa_from_text(grammar, expected):
     [
         (grammar_1, {"S -> ($.(a.b))"}),
         (grammar_2, {"S -> ($.a)"}),
+        (grammar_3, {"S -> ($.(a|b))", "S -> ($.(b|a))"}),
     ],
 )
 def test_rsa_to_text(grammar, expected):
@@ -34,7 +43,7 @@ def test_rsa_to_text(grammar, expected):
 
     actual = set(cfpq_data.rsa_to_text(rsa).splitlines())
 
-    assert actual == expected
+    assert actual.issubset(expected)
 
 
 @pytest.mark.parametrize(
@@ -42,6 +51,7 @@ def test_rsa_to_text(grammar, expected):
     [
         grammar_1,
         grammar_2,
+        grammar_3,
     ],
 )
 def test_rsa_from_and_to_txt(grammar):

--- a/tests/grammars/readwrite/test_rsa_readwrite.py
+++ b/tests/grammars/readwrite/test_rsa_readwrite.py
@@ -35,6 +35,7 @@ def test_rsa_from_text(grammar, expected):
         (grammar_1, {"S -> ($.(a.b))"}),
         (grammar_2, {"S -> ($.a)"}),
         (grammar_3, {"S -> ($.(a|b))", "S -> ($.(b|a))"}),
+        (grammar_4, {"S -> $"}),
     ],
 )
 def test_rsa_to_text(grammar, expected):
@@ -47,11 +48,7 @@ def test_rsa_to_text(grammar, expected):
 
 @pytest.mark.parametrize(
     "grammar",
-    [
-        grammar_1,
-        grammar_2,
-        grammar_3,
-    ],
+    [grammar_1, grammar_2, grammar_3, grammar_4],
 )
 def test_rsa_from_and_to_txt(grammar):
     (fd, fname) = tempfile.mkstemp()
@@ -65,4 +62,6 @@ def test_rsa_from_and_to_txt(grammar):
     os.close(fd)
     os.unlink(fname)
 
-    assert rsa_1 == rsa_2
+    assert rsa_1.labels == rsa_2.labels and all(
+        [rsa_1.get_box(label) == rsa_2.get_box(label) for label in rsa_1.labels]
+    )

--- a/tests/grammars/readwrite/test_rsa_readwrite.py
+++ b/tests/grammars/readwrite/test_rsa_readwrite.py
@@ -22,7 +22,6 @@ grammar_4 = "S -> \n#comment"
 )
 def test_rsa_from_text(grammar, expected):
     rsa = cfpq_data.rsa_from_text(grammar)
-    print(cfpq_data.rsa_to_text(rsa))
     cfg_from_rsa = cfpq_data.cfg_from_rsa(rsa)
 
     for word in expected:
@@ -66,6 +65,4 @@ def test_rsa_from_and_to_txt(grammar):
     os.close(fd)
     os.unlink(fname)
 
-    assert set(cfpq_data.rsa_to_text(rsa_1).splitlines()) == set(
-        cfpq_data.rsa_to_text(rsa_2).splitlines()
-    )
+    assert rsa_1 == rsa_2

--- a/tests/grammars/readwrite/test_rsm_readwrite.py
+++ b/tests/grammars/readwrite/test_rsm_readwrite.py
@@ -1,3 +1,4 @@
+# TODO: Remove in cfpq_data 2.0.0
 import os
 import tempfile
 

--- a/tests/graphs/generators/test_labeled_scale_free_graph.py
+++ b/tests/graphs/generators/test_labeled_scale_free_graph.py
@@ -14,7 +14,7 @@ g2 = cfpq_data.labeled_scale_free_graph(42, seed=seed, verbose=False)
 
 
 @pytest.mark.parametrize(
-    "graph,expected_nodes,expected_edges", [(g1, 29, 56), (g2, 42, 88)]
+    "graph,expected_nodes,expected_edges", [(g1, 29, 54), (g2, 42, 81)]
 )
 def test_labeled_scale_free_graph(graph, expected_nodes, expected_edges):
     assert (


### PR DESCRIPTION
Since [RSA was added](https://github.com/Aunsiels/pyformlang/pull/3) to the [pyformlang](https://github.com/Aunsiels/pyformlang), RSM support is discontinued and replaced with functions based on RSA.
The functions for working with the RSM will be replaced by the corresponding functions for working with the RSA in `cfpq_data 2.0.0`:

```python
rsm_from_cfg() -> rsa_from_cfg()
rsm_from_cnf() -> rsa_from_cnf()
rsm_from_text() -> rsa_from_text()
rsm_to_text() -> rsa_to_text()
rsm_from_txt() -> rsa_from_txt()
rsm_to_txt() -> rsa_to_txt()
```



